### PR TITLE
feat: :sparkles: added usergroup expanded list + member check api

### DIFF
--- a/src/main/java/com/strandls/userGroup/ApiConstants.java
+++ b/src/main/java/com/strandls/userGroup/ApiConstants.java
@@ -21,6 +21,7 @@ public class ApiConstants {
 	public static final String FEATURED = "/featured";
 	public static final String UNFEATURED = "/unfeatured";
 	public static final String ALL = "/all";
+	public static final String LIST = "/list";
 	public static final String FILTERRULE = "/filterRule";
 	public static final String BULK = "/bulk";
 	public static final String MIGRATE = "/migrate";

--- a/src/main/java/com/strandls/userGroup/controller/UserGroupController.java
+++ b/src/main/java/com/strandls/userGroup/controller/UserGroupController.java
@@ -262,7 +262,7 @@ public class UserGroupController {
 	@Path(ApiConstants.LIST)
 	@Produces(MediaType.APPLICATION_JSON)
 
-	@ApiOperation(value = "Find all the UserGroups for list page", notes = "Returns all the UserGroups for list page", response = UserGroupIbp.class, responseContainer = "List")
+	@ApiOperation(value = "Find all the UserGroups for list page", notes = "Returns all the UserGroups for list page", response = UserGroupExpanded.class, responseContainer = "List")
 	@ApiResponses(value = {
 			@ApiResponse(code = 404, message = "Unable to fetch the UserGroups list", response = String.class) })
 
@@ -1092,8 +1092,7 @@ public class UserGroupController {
 	}
 
 	@GET
-	@Path(ApiConstants.MEMBER + "/list")
-	@Consumes(MediaType.TEXT_PLAIN)
+	@Path(ApiConstants.MEMBER + ApiConstants.LIST)
 	@Produces(MediaType.APPLICATION_JSON)
 
 	@ValidateUser

--- a/src/main/java/com/strandls/userGroup/controller/UserGroupController.java
+++ b/src/main/java/com/strandls/userGroup/controller/UserGroupController.java
@@ -1,9 +1,10 @@
 /**
- * 
+ *
  */
 package com.strandls.userGroup.controller;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -46,6 +47,7 @@ import com.strandls.userGroup.pojo.UserGroupAddMemebr;
 import com.strandls.userGroup.pojo.UserGroupCreateData;
 import com.strandls.userGroup.pojo.UserGroupDocCreateData;
 import com.strandls.userGroup.pojo.UserGroupEditData;
+import com.strandls.userGroup.pojo.UserGroupExpanded;
 import com.strandls.userGroup.pojo.UserGroupFilterEnable;
 import com.strandls.userGroup.pojo.UserGroupFilterRemove;
 import com.strandls.userGroup.pojo.UserGroupFilterRuleInputData;
@@ -250,6 +252,23 @@ public class UserGroupController {
 	public Response getAllUserGroup() {
 		try {
 			List<UserGroupIbp> result = ugServices.fetchAllUserGroup();
+			return Response.status(Status.OK).entity(result).build();
+		} catch (Exception e) {
+			return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
+		}
+	}
+
+	@GET
+	@Path(ApiConstants.LIST)
+	@Produces(MediaType.APPLICATION_JSON)
+
+	@ApiOperation(value = "Find all the UserGroups for list page", notes = "Returns all the UserGroups for list page", response = UserGroupIbp.class, responseContainer = "List")
+	@ApiResponses(value = {
+			@ApiResponse(code = 404, message = "Unable to fetch the UserGroups list", response = String.class) })
+
+	public Response getAllUserGroupList() {
+		try {
+			List<UserGroupExpanded> result = ugServices.fetchAllUserGroupExpanded();
 			return Response.status(Status.OK).entity(result).build();
 		} catch (Exception e) {
 			return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
@@ -1068,6 +1087,35 @@ public class UserGroupController {
 			return Response.status(Status.NOT_FOUND).build();
 
 		} catch (Exception e) {
+			return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
+		}
+	}
+
+	@GET
+	@Path(ApiConstants.MEMBER + "/list")
+	@Consumes(MediaType.TEXT_PLAIN)
+	@Produces(MediaType.APPLICATION_JSON)
+
+	@ValidateUser
+	@ApiOperation(value = "list all groups by membership status", notes = "returns true and false", response = Boolean.class)
+	@ApiResponses(value = { @ApiResponse(code = 400, message = "unable to fetch the data", response = String.class) })
+
+	public Response userGroupMemberList(@Context HttpServletRequest request) {
+		try {
+			CommonProfile profile = AuthUtil.getProfileFromRequest(request);
+			Long userId = Long.parseLong(profile.getId());
+
+			List<UserGroupIbp> userGroupList = ugServices.fetchAllUserGroup();
+			Map<Long, Boolean> result = new HashMap<Long, Boolean>();
+
+			for (UserGroupIbp userGroup : userGroupList) {
+				Boolean isMember = ugMemberService.checkUserGroupMember(userId, userGroup.getId());
+				result.put(userGroup.getId(), isMember);
+			}
+
+			return Response.status(Status.OK).entity(result).build();
+		} catch (Exception e) {
+
 			return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
 		}
 	}

--- a/src/main/java/com/strandls/userGroup/pojo/UserGroupExpanded.java
+++ b/src/main/java/com/strandls/userGroup/pojo/UserGroupExpanded.java
@@ -1,0 +1,136 @@
+package com.strandls.userGroup.pojo;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author Harsh Zalavadiya
+ *
+ */
+public class UserGroupExpanded {
+
+	private Long id;
+	private String name;
+	private String icon;
+	private String webAddress;
+	private Boolean isParticipatory;
+	private Long memberCount;
+	private Date foundedOn;
+	private Date startDate;
+	private List<Long> speciesGroupIds;
+	private List<Long> habitatIds;
+
+	/**
+	 *
+	 */
+	public UserGroupExpanded() {
+		super();
+	}
+
+	/**
+	 * @param id
+	 * @param name
+	 * @param icon
+	 * @param webAddress
+	 * @param isParticipatory
+	 * @param memberCount
+	 * @param foundedOn
+	 * @param startDate
+	 * @param speciesGroupIds
+	 * @param habitatIds
+	 */
+	public UserGroupExpanded(Long id, String name, String icon, String webAddress, Boolean isParticipatory, Long memberCount, Date foundedOn, Date startDate, List<Long> speciesGroupIds, List<Long> habitatIds) {
+		super();
+		this.id = id;
+		this.name = name;
+		this.icon = icon;
+		this.webAddress = webAddress;
+		this.isParticipatory = isParticipatory;
+		this.memberCount = memberCount;
+		this.foundedOn = foundedOn;
+		this.startDate = startDate;
+		this.speciesGroupIds = speciesGroupIds;
+		this.habitatIds = habitatIds;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getIcon() {
+		return icon;
+	}
+
+	public void setIcon(String icon) {
+		this.icon = icon;
+	}
+
+	public String getWebAddress() {
+		return webAddress;
+	}
+
+	public void setWebAddress(String webAddress) {
+		this.webAddress = webAddress;
+	}
+
+	public Boolean getIsParticipatory() {
+		return isParticipatory;
+	}
+
+	public void setIsParticipatory(Boolean isParticipatory) {
+		this.isParticipatory = isParticipatory;
+	}
+
+	public Long getMemberCount() {
+		return memberCount;
+	}
+
+	public void setMemberCount(Long memberCount) {
+		this.memberCount = memberCount;
+	}
+
+	public Date getFoundedOn() {
+		return foundedOn;
+	}
+
+	public void setFoundedOn(Date foundedOn) {
+		this.foundedOn = foundedOn;
+	}
+
+	public Date getStartDate() {
+		return startDate;
+	}
+
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+
+	public List<Long> getSpeciesGroupIds() {
+		return speciesGroupIds;
+	}
+
+	public void setSpeciesGroupIds(List<Long> speciesGroupIds) {
+		this.speciesGroupIds = speciesGroupIds;
+	}
+
+	public List<Long> getHabitatIds() {
+		return habitatIds;
+	}
+
+	public void setHabitatIds(List<Long> habitatIds) {
+		this.habitatIds = habitatIds;
+	}
+
+}

--- a/src/main/java/com/strandls/userGroup/pojo/UserGroupExpanded.java
+++ b/src/main/java/com/strandls/userGroup/pojo/UserGroupExpanded.java
@@ -39,7 +39,8 @@ public class UserGroupExpanded {
 	 * @param speciesGroupIds
 	 * @param habitatIds
 	 */
-	public UserGroupExpanded(Long id, String name, String icon, String webAddress, Boolean isParticipatory, Long memberCount, Date foundedOn, Date startDate, List<Long> speciesGroupIds, List<Long> habitatIds) {
+	public UserGroupExpanded(Long id, String name, String icon, String webAddress, Boolean isParticipatory,
+			Long memberCount, Date foundedOn, Date startDate, List<Long> speciesGroupIds, List<Long> habitatIds) {
 		super();
 		this.id = id;
 		this.name = name;

--- a/src/main/java/com/strandls/userGroup/service/UserGroupSerivce.java
+++ b/src/main/java/com/strandls/userGroup/service/UserGroupSerivce.java
@@ -24,6 +24,7 @@ import com.strandls.userGroup.pojo.UserGroupAddMemebr;
 import com.strandls.userGroup.pojo.UserGroupCreateData;
 import com.strandls.userGroup.pojo.UserGroupDocCreateData;
 import com.strandls.userGroup.pojo.UserGroupEditData;
+import com.strandls.userGroup.pojo.UserGroupExpanded;
 import com.strandls.userGroup.pojo.UserGroupHomePageEditData;
 import com.strandls.userGroup.pojo.UserGroupIbp;
 import com.strandls.userGroup.pojo.UserGroupInvitationData;
@@ -55,6 +56,8 @@ public interface UserGroupSerivce {
 			UserGroupMappingCreateData userGorups);
 
 	public List<UserGroupIbp> fetchAllUserGroup();
+
+	public List<UserGroupExpanded> fetchAllUserGroupExpanded();
 
 	public List<Featured> fetchFeatured(String objectType, Long id);
 

--- a/src/main/java/com/strandls/userGroup/service/impl/UserGroupServiceImpl.java
+++ b/src/main/java/com/strandls/userGroup/service/impl/UserGroupServiceImpl.java
@@ -63,6 +63,7 @@ import com.strandls.userGroup.pojo.UserGroupCreateData;
 import com.strandls.userGroup.pojo.UserGroupDocCreateData;
 import com.strandls.userGroup.pojo.UserGroupDocument;
 import com.strandls.userGroup.pojo.UserGroupEditData;
+import com.strandls.userGroup.pojo.UserGroupExpanded;
 import com.strandls.userGroup.pojo.UserGroupHabitat;
 import com.strandls.userGroup.pojo.UserGroupHomePageEditData;
 import com.strandls.userGroup.pojo.UserGroupIbp;
@@ -381,6 +382,59 @@ public class UserGroupServiceImpl implements UserGroupSerivce {
 		} catch (Exception e) {
 			logger.error(e.getMessage());
 		}
+		return result;
+	}
+
+	@Override
+	public List<UserGroupExpanded> fetchAllUserGroupExpanded() {
+		List<UserGroupExpanded> result = new ArrayList<UserGroupExpanded>();
+
+		try {
+			List<UserGroup> userGroupList = userGroupDao.findAll();
+			List<UserGroupMembersCount> count = ugMemberService.getUserGroupMemberCount();
+			Map<Long, UserGroupExpanded> ugMap = new HashMap<Long, UserGroupExpanded>();
+			UserGroupExpanded ibp = null;
+			for (UserGroup userGroup : userGroupList) {
+
+				List<UserGroupSpeciesGroup> ugSpeciesGroups = ugSGroupDao.findByUserGroupId(userGroup.getId());
+				List<UserGroupHabitat> ugHabitats = ugHabitatDao.findByUserGroupId(userGroup.getId());
+				List<Long> speciesGroupIds = new ArrayList<Long>();
+				List<Long> habitatIds = new ArrayList<Long>();
+				for (UserGroupSpeciesGroup ugSpeciesGroup : ugSpeciesGroups) {
+					speciesGroupIds.add(ugSpeciesGroup.getSpeciesGroupId());
+				}
+				for (UserGroupHabitat ugHabitat : ugHabitats) {
+					habitatIds.add(ugHabitat.getHabitatId());
+				}
+
+				String webAddress = userGroup.getDomianName();
+
+				if (webAddress == null) {
+					webAddress = "/group/" + userGroup.getWebAddress();
+				}
+
+				ibp = new UserGroupExpanded(userGroup.getId(), userGroup.getName(), userGroup.getIcon(),
+						webAddress, userGroup.getAllowUserToJoin(), 0L, userGroup.getFoundedOn(), userGroup.getStartDate(), speciesGroupIds, habitatIds);
+
+				ugMap.put(userGroup.getId(), ibp);
+			}
+
+			// Iterate through member count and assign it to expanded modal
+			for (UserGroupMembersCount ugm : count) {
+				UserGroupExpanded ugx = ugMap.get(ugm.getUserGroupId());
+				ugx.setMemberCount(ugm.getCount());
+				result.add(ugx);
+				ugMap.remove(ugm.getUserGroupId());
+			}
+
+			for (Entry<Long, UserGroupExpanded> entry : ugMap.entrySet()) {
+				result.add(entry.getValue());
+			}
+
+		} catch (Exception e) {
+			logger.error(e.getMessage());
+		}
+
 		return result;
 	}
 


### PR DESCRIPTION
This PR adds two endpoints

- `/userGroup-api/api/v1/group/list` which lists all userGroups with some extra details for `group/list` page
- `/userGroup-api/api/v1/group/member/list` which lists all userGroups memberships against current user